### PR TITLE
Fix AV1 codec string to follow specification

### DIFF
--- a/src/demux.ts
+++ b/src/demux.ts
@@ -160,7 +160,7 @@ export async function videoStreamToConfig(
             // <profile>
             if (profile < 0)
                 profile = 0;
-            codec += `.0${profile}`;
+            codec += `.${profile}`;
 
             // <level><tier>
             if (level < 0)
@@ -178,28 +178,6 @@ export async function videoStreamToConfig(
             if (bitDepth.length < 2)
                 bitDepth = `0${bitDepth}`;
             codec += `.${bitDepth}`;
-
-            // <monochrome>
-            const nbComponents = await libav.AVPixFmtDescriptor_nb_components(desc);
-            if (nbComponents < 2)
-                codec += ".1";
-            else
-                codec += ".0";
-
-            // .<chromaSubsampling>
-            let subX = 0, subY = 0, subP = 0;
-            if (nbComponents < 2) {
-                // Monochrome is always considered subsampled (weirdly)
-                subX = 1;
-                subY = 1;
-            } else {
-                subX = await libav.AVPixFmtDescriptor_log2_chroma_w(desc);
-                subY = await libav.AVPixFmtDescriptor_log2_chroma_h(desc);
-                /* FIXME: subP (subsampling position) mainly represents the
-                 * *vertical* position, which doesn't seem to be exposed by
-                 * ffmpeg, at least not in a usable way */
-            }
-            codec += `.${subX}${subY}${subP}`;
 
             // FIXME: the rest are technically optional, so left out
             ret.codec = codec;


### PR DESCRIPTION
Removes the leading 0, monochrome and chromaSubsampling to fix the issues described below.

In the [W3 specification for using AV1 in Webcodecs](https://www.w3.org/TR/webcodecs-av1-codec-registration/#fully-qualified-codec-strings), it is said that the codec string is defined by the [AV1 Codec ISO Media File Format Binding](https://aomediacodec.github.io/av1-isobmff/#codecsparam).
In this document, it is said that 
`The profile parameter value, represented by a single digit decimal, SHALL equal the value of seq_profile in the Sequence Header OBU.`
The second problem is the inclusion of monochrome and chromaSubsampling, which are optional, but the specification says
`All the other fields (including their leading '.') are optional, mutually inclusive (all or none) fields.`
so including only monochrome and chromaSubsampling without the rest also invalidates the codec string.